### PR TITLE
Include string header

### DIFF
--- a/haccrypto/_crypto.cpp
+++ b/haccrypto/_crypto.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
+#include <string>
 #include <inttypes.h>
 
 extern "C" {


### PR DESCRIPTION
This is necessary to compile this library on Fedora 38.